### PR TITLE
fix: typecheck スクリプトの tsc の引数を修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "serve": "docusaurus serve",
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids",
-    "typecheck": "tsc --nolimt",
+    "typecheck": "tsc",
     "fix": "yarn format && yarn eslint:fix",
     "check": "prettier --check \"./**/*.{ts,tsx,js,md,mdx}\"",
     "format": "prettier --write \"./**/*.{ts,tsx,js,md,mdx}\"",


### PR DESCRIPTION
### 実施内容

`--nolimt` などというオプションは無く, デフォルトのカレントディレクトリの `tsconfig.json` を読む動作で問題ないので除去しました.
