### PR TITLE
docs: v1.33.0 の内容を追加

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -34,12 +34,16 @@ body:
         1.
         2.
         3.
+    validations:
+      required: true
   - type: textarea
     id: possible-solutions
     attributes:
       label: 期待される動作
       description: >
         この不具合が発生していなかったときの期待される動作を説明してください。
+    validations:
+      required: true
   - type: textarea
     id: notes
     attributes:
@@ -50,3 +54,6 @@ body:
     attributes:
       label: ブラウザとバージョン
       description: 使用しているブラウザとそのバージョンを説明します。(Google Chromeの場合は設定から確認できます)
+      render: Text
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/content_report.yml
+++ b/.github/ISSUE_TEMPLATE/content_report.yml
@@ -16,6 +16,5 @@ body:
       label: 提出内容
       description: >
         提出する内容を入力してください。
-      render: text
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -26,6 +26,8 @@ body:
       label: 理由
       description: >
         追加してほしい理由を説明してください。明確にするのが大切です。
+    validations:
+      required: true
   - type: textarea
     id: notes
     attributes:

--- a/docs/commands_docs/voice-channel/party.mdx
+++ b/docs/commands_docs/voice-channel/party.mdx
@@ -60,9 +60,10 @@ VC 内の人類に押しかけて Party を開くよ。
 
 はらちょが提供する BGM は以下の通りです。
 
-| ID                                                               | 元ネタ                                                                |
-| ---------------------------------------------------------------- | --------------------------------------------------------------------- |
-| COFFIN_INTRO                                                     | [Coffin Dance](https://www.youtube.com/watch?v=j9V78UbdzWI)           |
-| COFFIN_DROP                                                      | [Coffin Dance](https://www.youtube.com/watch?v=j9V78UbdzWI)           |
-| KAKAPO                                                           | 不明                                                                  |
-| KAKUSIN_DAISUKE <span class="badge badge--success">v1.9.0</span> | [LeaF - Twitter](https://twitter.com/7eaF/status/1509153813235892229) |
+| ID                                                  | 元ネタ                                                                              |
+| --------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| COFFIN_INTRO                                        | [Coffin Dance](https://www.youtube.com/watch?v=j9V78UbdzWI)                         |
+| COFFIN_DROP                                         | [Coffin Dance](https://www.youtube.com/watch?v=j9V78UbdzWI)                         |
+| KAKAPO                                              | 不明                                                                                |
+| KAKUSIN_DAISUKE <VersionBadge>v1.9.0</VersionBadge> | [LeaF - Twitter](https://twitter.com/7eaF/status/1509153813235892229)               |
+| PATATO <VersionBadge>v1.33.0</VersionBadge>         | [【マクドナルド公式】ティロリサウンド](https://www.youtube.com/watch?v=8NjhfastLts) |


### PR DESCRIPTION
### 実施内容

リリース予定の [OreOreBot2 v1.33.0](https://github.com/approvers/OreOreBot2/pull/667) の内容を追加します。

### 追加情報

バグレポート等複数のIssue Formがコードブロックになってしまう問題も #13 で修正しました。
