### PR TITLE
refactor: FC の使用を回避

### DIFF
--- a/src/component/FeatureBadge.tsx
+++ b/src/component/FeatureBadge.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 
-interface Props {
+export interface FeatureProps {
   children: React.ReactNode;
 }
 
-const FeatureBadge: React.FC<Props> = ({ children }) => {
+const FeatureBadge = ({ children }: FeatureProps): JSX.Element => {
   return <span className="badge badge--primary">{children}</span>;
 };
 

--- a/src/component/VersionBadge.tsx
+++ b/src/component/VersionBadge.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 
-interface VersionProps {
+export interface VersionProps {
   children: React.ReactNode;
 }
 
-const VersionBadge: React.FC<VersionProps> = ({ children }) => {
+const VersionBadge = ({ children }: VersionProps): JSX.Element => {
   return <span className="badge badge--success">{children}</span>;
 };
 

--- a/src/component/WarningBadge.tsx
+++ b/src/component/WarningBadge.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import Link from '@docusaurus/Link';
 
-interface Props {
+export interface WarningProps {
   children: React.ReactNode;
   to: string;
 }
 
-const WarningBadge: React.FC<Props> = ({ children, to }) => {
+const WarningBadge = ({ children, to }: WarningProps): JSX.Element => {
   return (
     <Link className="badge badge--warning" to={to}>
       {children}


### PR DESCRIPTION
### 実施内容

`React.FC` を使用していましたが, これは混乱を招くため使うべきではありません. そのため直接引数の型を明示するように修正しました.

また, コンポーネントを使う側にとって必要なことがある props の型情報が `export` されていませんでしたので, 型の名称を調整するなどして `export` しました.

#### `React.FC` の問題についての解説

`React.FC` については以前から以下のような様々な懸念が存在しており, わざわざ `React.FC<Props>` と書いても益になるどころか害になるケースがほとんどです.

- `React.FC` はその型定義がバージョンごとで変わる
- `React.FC` は `React.VFC` などと同じように非推奨になる可能性が高い
- `React.FC` はジェネリックな型なので, props の型定義自体にジェネリクスを使っているとうまく書けなくなる

特に, React v17 までは `React.FC` が `children` を追加していましたが, v18 からは足さなくなりました.

### 追加情報

`React.FC` を禁止する ESLint ルールを導入してもよいかもしれません.
