### PR TITLE
chore: strict の有効化

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   // This file is not used in compilation. It is here just for a nice editor experience.
   "extends": "@tsconfig/docusaurus/tsconfig.json",
   "compilerOptions": {
-    "baseUrl": "."
+    "baseUrl": ".",
+    "strict": true
   }
 }


### PR DESCRIPTION
### 実施内容

TypeScript でコンポーネントを書いていて気づいたのですが, `tsconfig.json` で `strict` が無効になっていたので有効化しました.
