### PR TITLE
docs(fix): takopi flag

### DIFF
--- a/docs/commands_docs/meme/takopi.mdx
+++ b/docs/commands_docs/meme/takopi.mdx
@@ -43,7 +43,7 @@ import VersionBadge from '../../../src/component/VersionBadge';
 m2en「わ、わかんないっピ.......」
 ```
 
-`!takopi 単位`
+`!takopi -f 単位`
 
 ```
 >> m2en「単位、出して」


### PR DESCRIPTION
### 実施内容

`!takopi -f` の Example が誤っていたので修正
