### PR TITLE
ci: merge_group トリガの追加

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,7 @@ name: Build
 
 on:
   pull_request:
+  merge_group:
 
 jobs:
   run_eslint:

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -2,6 +2,7 @@ name: eslint
 
 on:
   pull_request:
+  merge_group:
 
 jobs:
   run_eslint:


### PR DESCRIPTION
### 実施内容

main ブランチのブランチ保護において, マージするにあたって Required に指定した CI がいくつかあります. マージキューを用いてマージしようとすると, これらは従来の `pull_request` イベントではトリガされず `merge_group` イベントでトリガされるようです.

そこで, Required 指定されている build と eslint の CI に `merge_group` のトリガ条件を追記しました.

参考リンク: https://github.blog/changelog/2022-08-18-merge-group-webhook-event-and-github-actions-workflow-trigger/
